### PR TITLE
apm-1717: status requires a 'status: pass' for compatibility

### DIFF
--- a/docker/sync-wrap/src/app.postman.spec.js
+++ b/docker/sync-wrap/src/app.postman.spec.js
@@ -57,6 +57,7 @@ describe("express with postman-echo", function () {
         request(server)
             .get("/_status")
             .expect(200, {
+                status: "pass",
                 ping: "pong",
                 service: "sync-wrap",
                 _version: {}

--- a/docker/sync-wrap/src/app.slowapp.spec.js
+++ b/docker/sync-wrap/src/app.slowapp.spec.js
@@ -35,6 +35,7 @@ describe("express with slowapp no insecure", function () {
         request(server)
             .get("/_status")
             .expect(200, {
+                status: "pass",
                 ping: "pong",
                 service: "sync-wrap",
                 _version: {}
@@ -81,6 +82,7 @@ describe("express with slowap", function () {
         request(server)
             .get("/_status")
             .expect(200, {
+                status: "pass",
                 ping: "pong",
                 service: "sync-wrap",
                 _version: {}
@@ -171,6 +173,7 @@ describe("express with slowap with sub path", function () {
         request(server)
             .get("/_status")
             .expect(200, {
+                status: "pass",
                 ping: "pong",
                 service: "sync-wrap",
                 _version: {test: 123}

--- a/docker/sync-wrap/src/handlers.js
+++ b/docker/sync-wrap/src/handlers.js
@@ -249,6 +249,7 @@ const sleep = (delay) => {
 
 function ping_response(req) {
     return {
+        status: "pass",
         ping: "pong",
         service: req.app.locals.app_name,
         _version: req.app.locals.version_info


### PR DESCRIPTION
## Summary
* :sparkles: monitoring
